### PR TITLE
Add save/resume of scan progress (finish interrupted range on restart)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /ranges
+/progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV TELEGRAM_CHATID=""
 ENV CUSTOM_RANGE=""
 ENV CLOUDSEARCH_MODE="false"
 ENV SAVE_KEY="false"
+ENV SAVE_PROGRESS="true"
 
 COPY --from=build /build/vanitysearch /app/btcpuzzle
 COPY btcpuzzle.sh /app/btcpuzzle.sh

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@
 
 SRC = Base58.cpp IntGroup.cpp main.cpp Random.cpp \
       Timer.cpp Int.cpp IntMod.cpp Point.cpp SECP256K1.cpp \
-      Vanity.cpp GPU/GPUGenerate.cpp hash/ripemd160.cpp \
+      Vanity.cpp RangeMath.cpp GPU/GPUGenerate.cpp hash/ripemd160.cpp \
       hash/sha256.cpp hash/sha512.cpp hash/ripemd160_sse.cpp \
       hash/sha256_sse.cpp Bech32.cpp Wildcard.cpp \
-      Pool/PoolConfig.cpp Pool/PoolClient.cpp Pool/Logger.cpp
+      Pool/PoolConfig.cpp Pool/PoolClient.cpp Pool/Logger.cpp Pool/Checkpoint.cpp
 
 OBJDIR = obj
 
@@ -29,20 +29,20 @@ ifdef gpu
 
 OBJET = $(addprefix $(OBJDIR)/, \
         Base58.o IntGroup.o main.o Random.o Timer.o Int.o \
-        IntMod.o Point.o SECP256K1.o Vanity.o GPU/GPUGenerate.o \
+        IntMod.o Point.o SECP256K1.o Vanity.o RangeMath.o GPU/GPUGenerate.o \
         hash/ripemd160.o hash/sha256.o hash/sha512.o \
         hash/ripemd160_sse.o hash/sha256_sse.o \
         GPU/GPUEngine.o Bech32.o Wildcard.o \
-        Pool/PoolConfig.o Pool/PoolClient.o Pool/Logger.o)
+        Pool/PoolConfig.o Pool/PoolClient.o Pool/Logger.o Pool/Checkpoint.o)
 
 else
 
 OBJET = $(addprefix $(OBJDIR)/, \
         Base58.o IntGroup.o main.o Random.o Timer.o Int.o \
-        IntMod.o Point.o SECP256K1.o Vanity.o GPU/GPUGenerate.o \
+        IntMod.o Point.o SECP256K1.o Vanity.o RangeMath.o GPU/GPUGenerate.o \
         hash/ripemd160.o hash/sha256.o hash/sha512.o \
         hash/ripemd160_sse.o hash/sha256_sse.o Bech32.o Wildcard.o \
-		Pool/PoolConfig.o Pool/PoolClient.o Pool/Logger.o)
+		Pool/PoolConfig.o Pool/PoolClient.o Pool/Logger.o Pool/Checkpoint.o)
 
 endif
 

--- a/Pool/Checkpoint.cpp
+++ b/Pool/Checkpoint.cpp
@@ -1,0 +1,84 @@
+#include "Checkpoint.h"
+#include <fstream>
+#include <cstdio>
+#include <cstdlib>
+
+static const char* CP_HEADER = "btcpuzzle-checkpoint v1";
+
+// Strict base-10 int parse: false if empty or contains non-numeric chars.
+static bool parseIntStrict(const std::string& s, int& out) {
+    if (s.empty()) return false;
+    char* end = nullptr;
+    long v = std::strtol(s.c_str(), &end, 10);
+    if (end == s.c_str() || *end != '\0') return false;
+    out = (int)v;
+    return true;
+}
+
+bool CheckpointIO::save(const std::string& path, const Checkpoint& cp) {
+    const std::string tmp = path + ".tmp";
+    {
+        std::ofstream out(tmp, std::ios::trunc);
+        if (!out.is_open()) return false;
+        out << CP_HEADER << "\n";
+        out << "puzzle=" << cp.puzzle << "\n";
+        out << "hex=" << cp.hex << "\n";
+        out << "rangeStart=" << cp.rangeStart << "\n";
+        out << "rangeEnd=" << cp.rangeEnd << "\n";
+        out << "target=" << cp.targetAddress << "\n";
+        out << "numThreads=" << cp.numThreads << "\n";
+        out << "offset=" << cp.offsetHex << "\n";
+        for (const auto& a : cp.proofAddresses) out << "proof=" << a << "\n";
+        // addresses (Base58/Bech32) and hex keys contain no spaces -> single space is a safe separator
+        for (const auto& p : cp.foundProof)     out << "found=" << p.first << " " << p.second << "\n";
+        out.flush();
+        if (!out.good()) { out.close(); std::remove(tmp.c_str()); return false; }
+    }
+    std::remove(path.c_str());  // Windows rename() fails if destination exists
+    if (std::rename(tmp.c_str(), path.c_str()) != 0) { std::remove(tmp.c_str()); return false; }
+    return true;
+}
+
+bool CheckpointIO::load(const std::string& path, Checkpoint& out) {
+    std::ifstream in(path);
+    if (!in.is_open()) return false;
+
+    std::string line;
+    if (!std::getline(in, line)) return false;
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (line != CP_HEADER) return false;
+
+    Checkpoint cp;
+    bool havePuzzle = false, haveNumThreads = false;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        if (line.empty()) continue;
+        size_t eq = line.find('=');
+        if (eq == std::string::npos) continue;
+        const std::string key = line.substr(0, eq);
+        const std::string val = line.substr(eq + 1);
+        if (key == "puzzle")          { if (!parseIntStrict(val, cp.puzzle)) return false; havePuzzle = true; }
+        else if (key == "hex")         cp.hex = val;
+        else if (key == "rangeStart")  cp.rangeStart = val;
+        else if (key == "rangeEnd")    cp.rangeEnd = val;
+        else if (key == "target")      cp.targetAddress = val;
+        else if (key == "numThreads") { if (!parseIntStrict(val, cp.numThreads)) return false; haveNumThreads = true; }
+        else if (key == "offset")      cp.offsetHex = val;
+        else if (key == "proof")       cp.proofAddresses.push_back(val);
+        else if (key == "found") {
+            // separator invariant: address/hex key contain no spaces. A malformed
+            // line without a space is skipped (load still succeeds) -- resume re-finds it.
+            size_t sp = val.find(' ');
+            if (sp != std::string::npos)
+                cp.foundProof.emplace_back(val.substr(0, sp), val.substr(sp + 1));
+        }
+    }
+    if (!havePuzzle || !haveNumThreads) return false;
+    out = cp;
+    return true;
+}
+
+void CheckpointIO::clear(const std::string& path) {
+    std::remove(path.c_str());
+    std::remove((path + ".tmp").c_str());
+}

--- a/Pool/Checkpoint.h
+++ b/Pool/Checkpoint.h
@@ -1,0 +1,30 @@
+// Checkpoint persistence for resumable scan progress (pure std C++, no GPU/CUDA).
+#ifndef POOL_CHECKPOINT_H
+#define POOL_CHECKPOINT_H
+
+#include <string>
+#include <vector>
+#include <utility>
+
+struct Checkpoint {
+    int puzzle = 0;
+    std::string hex;
+    std::string rangeStart;
+    std::string rangeEnd;
+    std::string targetAddress;
+    std::vector<std::string> proofAddresses;
+    int numThreads = 0;
+    std::string offsetHex;                                        // per-thread advance, hex
+    std::vector<std::pair<std::string, std::string>> foundProof;  // (address, privKeyHex)
+};
+
+namespace CheckpointIO {
+    // Atomic write (temp file + rename). Returns false on I/O error.
+    bool save(const std::string& path, const Checkpoint& cp);
+    // Returns true only if a well-formed checkpoint was read.
+    bool load(const std::string& path, Checkpoint& out);
+    // Remove checkpoint (and any leftover temp). No error if absent.
+    void clear(const std::string& path);
+}
+
+#endif // POOL_CHECKPOINT_H

--- a/Pool/PoolClient.cpp
+++ b/Pool/PoolClient.cpp
@@ -98,6 +98,12 @@ bool PoolClient::init() {
 	else {
 		logMessage(WARNING, "Save Key To Account  => Disabled");
 	}
+	if (config.saveProgress) {
+		logMessage(INFO, "Save Progress        => Enabled");
+	}
+	else {
+		logMessage(WARNING, "Save Progress        => Disabled");
+	}
 	std::cout << "========================================" << std::endl;
 
 	// Pool client init
@@ -492,8 +498,11 @@ void PoolClient::onKeyFound(const std::string& address, const std::string& priva
 	fk.isReward = false;
 	fk.isTarget = false;
 
-	foundKeys[address] = fk;
-	keysFound++;
+	{
+		std::lock_guard<std::mutex> lk(foundKeysMutex);
+		foundKeys[address] = fk;
+		keysFound++;
+	}
 
 	std::cout << "[+] Key found: " << address << std::endl;
 
@@ -502,6 +511,7 @@ void PoolClient::onKeyFound(const std::string& address, const std::string& priva
 }
 
 bool PoolClient::hasAllProofKeys(const RangeData& range) {
+	std::lock_guard<std::mutex> lk(foundKeysMutex);
 	int found = 0;
 	for (const auto& addr : range.proofOfWorkAddresses) {
 		if (foundKeys.find(addr) != foundKeys.end()) {
@@ -512,6 +522,7 @@ bool PoolClient::hasAllProofKeys(const RangeData& range) {
 }
 
 std::vector<std::string> PoolClient::getProofKeys(const RangeData& range) {
+	std::lock_guard<std::mutex> lk(foundKeysMutex);
 	std::vector<std::string> proofKeys;
 	for (const auto& addr : range.proofOfWorkAddresses) {
 		if (foundKeys.find(addr) != foundKeys.end()) {
@@ -519,6 +530,18 @@ std::vector<std::string> PoolClient::getProofKeys(const RangeData& range) {
 		}
 	}
 	return proofKeys;
+}
+
+std::vector<std::pair<std::string, std::string>> PoolClient::getFoundProofPairs(const RangeData& range) {
+	std::lock_guard<std::mutex> lk(foundKeysMutex);
+	std::vector<std::pair<std::string, std::string>> pairs;
+	for (const auto& addr : range.proofOfWorkAddresses) {
+		auto it = foundKeys.find(addr);
+		if (it != foundKeys.end()) {
+			pairs.emplace_back(addr, it->second.privateKey);
+		}
+	}
+	return pairs;
 }
 
 bool PoolClient::notifyWorkerStarted() {

--- a/Pool/PoolClient.h
+++ b/Pool/PoolClient.h
@@ -9,6 +9,8 @@
 #include <thread>
 #include <atomic>
 #include <chrono>
+#include <mutex>
+#include <utility>
 #include <curl/curl.h>
 #include "PoolConfig.h"
 #include <openssl/sha.h>
@@ -49,6 +51,7 @@ private:
     std::string currentRangeHex;
 
     std::map<std::string, FoundKey> foundKeys;
+    std::mutex foundKeysMutex;
     int rangesScanned;
     int keysFound;
     time_t startTime;
@@ -111,6 +114,8 @@ public:
 
     // Get list of found proof keys
     std::vector<std::string> getProofKeys(const RangeData& range);
+    // (address, privKeyHex) pairs for proof addresses found so far (for checkpointing)
+    std::vector<std::pair<std::string, std::string>> getFoundProofPairs(const RangeData& range);
     std::string encryptData(const std::string& data);
     
 

--- a/Pool/PoolConfig.cpp
+++ b/Pool/PoolConfig.cpp
@@ -103,6 +103,7 @@ PoolConfig PoolConfig::loadFromFile(const std::string& filepath) {
         else if (key == "api_share_url") config.apiShareUrl = value;
         else if (key == "custom_range") config.customRange = value;
         else if (key == "save_key") config.saveKeyToBtcPuzzle = parseBool(value);
+        else if (key == "save_progress") config.saveProgress = parseBool(value);
     }
 
     file.close();

--- a/Pool/PoolConfig.h
+++ b/Pool/PoolConfig.h
@@ -41,6 +41,9 @@ public:
     std::string customRange = "none";
     std::string securityHash = "";
 
+    // Save/resume scan progress to disk (resume an interrupted range on restart)
+    bool saveProgress = true;
+
     // Application code hash
     std::string appCodeHash = "";
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Example: ```./btcpuzzle -puzzle 71 ...```
 
 -savekey => Save the encrypted key to btcpuzzle.info account. (RSA public key required)
 
+-saveprogress => Save/resume scan progress (true|false, default true). On restart the client finishes the interrupted range and submits it before requesting a new one.
+
 ```
 
 # Default Settings
@@ -120,6 +122,9 @@ save_key=false
 
 # Other Settings
 custom_range=none
+
+# Save/resume scan progress (resume an interrupted range on restart)
+save_progress=true
 
 ```
 

--- a/RangeMath.cpp
+++ b/RangeMath.cpp
@@ -1,0 +1,32 @@
+#include "RangeMath.h"
+
+namespace RangeMath {
+
+Int perThreadDiff(Int& start, Int& end, int numThreads) {
+    if (numThreads <= 0) { Int z; z.SetInt32(0); return z; }
+    Int diff(&end);
+    if (diff.IsOdd()) diff.AddOne();
+    diff.Sub(&start);
+    Int n; n.SetInt32((uint32_t)numThreads);
+    diff.Div(&n);
+    return diff;
+}
+
+Int threadStart(Int& start, Int& diff, int idx) {
+    Int d(&diff);
+    Int k; k.SetInt32((uint32_t)idx);
+    d.Mult(&k);          // d = diff * idx
+    Int s(&start);
+    s.Add(&d);           // s = start + diff*idx
+    return s;
+}
+
+Int offsetFromCount(uint64_t totalCount, int numThreads) {
+    if (numThreads <= 0) { Int z; z.SetInt32(0); return z; }
+    Int c(totalCount);   // Int(uint64_t)
+    Int n; n.SetInt32((uint32_t)numThreads);
+    c.Div(&n);
+    return c;
+}
+
+} // namespace RangeMath

--- a/RangeMath.h
+++ b/RangeMath.h
@@ -1,0 +1,17 @@
+// Pure partition arithmetic over Int (no GPU). Must stay in sync with
+// VanitySearch::getGPUStartingKeysMT (Vanity.cpp).
+#ifndef RANGEMATH_H
+#define RANGEMATH_H
+
+#include "Int.h"
+
+namespace RangeMath {
+    // Per-thread sub-range width: (end[+1 if odd] - start) / numThreads.
+    Int perThreadDiff(Int& start, Int& end, int numThreads);
+    // Start key of thread idx: start + diff*idx.
+    Int threadStart(Int& start, Int& diff, int idx);
+    // Per-thread scan advance derived from total device key count: count / numThreads.
+    Int offsetFromCount(uint64_t totalCount, int numThreads);
+}
+
+#endif // RANGEMATH_H

--- a/Vanity.cpp
+++ b/Vanity.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "Vanity.h"
+#include "RangeMath.h"
 #include "Base58.h"
 #include "Bech32.h"
 #include "hash/sha256.h"
@@ -163,7 +164,11 @@ VanitySearch::VanitySearch(Secp256K1* secp, vector<std::string>& inputAddresses,
 	beta2.SetBase16("851695d49a83f8ef919bb86153cbcb16630fb68aed0a766a3ec693d68e6afa40");
 	lambda2.SetBase16("ac9c52b33fa3cf1f5ad9e3fd77ed9ba4a880b9fc8ec739c2e0cfc810b51283ce");
 
-	startKey.Set(&bc->ksNext);	
+	startKey.Set(&bc->ksNext);
+	resumeOffset.SetInt32(0);
+	appliedResumeOffset.SetInt32(0);
+	resumeExpectedThreads = 0;
+	savedNumThreads = 0;
 
 	char* ctimeBuff;
 	time_t now = time(NULL);
@@ -877,19 +882,17 @@ void VanitySearch::getGPUStartingKeysMT(Int& tRangeStart, Int& tRangeEnd, int gr
 
 	Int tNumThreadsGPU;
 	tNumThreadsGPU.SetInt32(numThreadsGPU);
-	tRangeDiffPerGPUThread.Set(&tRangeEnd);
-	if (tRangeDiffPerGPUThread.IsOdd())
+	// Global span (end[+1 if odd] - start), used below for CPU-thread division.
+	Int tRangeDiffGlobal(&tRangeEnd);
+	if (tRangeDiffGlobal.IsOdd())
 	{
-		tRangeDiffPerGPUThread.AddOne();
+		tRangeDiffGlobal.AddOne();
 	}
-	tRangeDiffPerGPUThread.Sub(&tRangeStart);
+	tRangeDiffGlobal.Sub(&tRangeStart);
 
-	Int tRangeDiffGlobal(&tRangeDiffPerGPUThread);
-
-	// this only needed if total GPU threads not power of 2
-	//tRangeDiffPerThread.Add(&numThreads);
-
-	tRangeDiffPerGPUThread.Div(&tNumThreadsGPU);
+	// Per-GPU-thread width (kept in sync with RangeMath, used by tests/resume).
+	Int _ptd = RangeMath::perThreadDiff(tRangeStart, tRangeEnd, numThreadsGPU);
+	tRangeDiffPerGPUThread.Set(&_ptd);
 
 	firstGPUThreadLastPrivateKey.Set(&tRangeStart);
 	firstGPUThreadLastPrivateKey.Add(&tRangeDiffPerGPUThread);	
@@ -936,6 +939,7 @@ void VanitySearch::FindKeyGPU(TH_PARAM* ph) {
 	int thId = ph->threadId;
 	GPUEngine g(ph->gridSizeX, ph->gridSizeY, ph->gpuId, maxFound);
 	int numThreadsGPU = g.GetNumThreadsGPU();
+	savedNumThreads = numThreadsGPU;
 	Point* publicKeys = new Point[numThreadsGPU];
 	Int* privateKeys = new Int[numThreadsGPU];
 	vector<ITEM> found;
@@ -951,7 +955,32 @@ void VanitySearch::FindKeyGPU(TH_PARAM* ph) {
 
 	//getGPUStartingKeys(bc->ksStart, bc->ksFinish, g.GetGroupSize(), numThreadsGPU, privateKeys, publicKeys);
 	getGPUStartingKeysMT(bc->ksStart, bc->ksFinish, g.GetGroupSize(), numThreadsGPU, privateKeys, publicKeys);
-	
+
+	// Resume: shift each thread's start key by the saved per-thread offset.
+	if (!resumeOffset.IsZero()) {
+		Int effOffset(&resumeOffset);
+		if (resumeExpectedThreads != numThreadsGPU) {
+			fprintf(stdout, "[RESUME] GPU thread count changed (%d -> %d): full range re-scan\n",
+				resumeExpectedThreads, numThreadsGPU);
+			fflush(stdout);
+			effOffset.SetInt32(0);
+		}
+		if (!effOffset.IsZero()) {
+			int gs = g.GetGroupSize();
+			for (int i = 0; i < numThreadsGPU; i++) {
+				privateKeys[i].Add(&effOffset);
+				Int pk(&privateKeys[i]);
+				pk.Add((uint64_t)(gs / 2));
+				publicKeys[i] = secp->ComputePublicKey(&pk);
+			}
+			fprintf(stdout, "[RESUME] resumed from per-thread offset 0x%s\n", effOffset.GetBase16().c_str());
+			fflush(stdout);
+		}
+		// Record the offset actually applied (0 on full re-scan fallback) so the
+		// monitor thread can report an ABSOLUTE checkpoint offset during resume.
+		appliedResumeOffset.Set(&effOffset);
+	}
+
 	// copy to gpu
 	ok = g.SetKeys(publicKeys);
 
@@ -1027,21 +1056,6 @@ uint64_t VanitySearch::getGPUCount() {
 	return count;
 }
 
-void VanitySearch::saveProgress(TH_PARAM* p, Int& lastSaveKey, BITCRACK_PARAM* bc) {
-
-	Int lowerKey;
-	lowerKey.Set(&p[0].THnextKey);
-
-	int total = numGPUs;
-	for (int i = 0; i < total; i++) {
-		if (p[i].THnextKey.IsLower(&lowerKey))
-			lowerKey.Set(&p[i].THnextKey);
-	}
-
-	if (lowerKey.IsLowerOrEqual(&lastSaveKey)) return;
-	lastSaveKey.Set(&lowerKey);
-}
-
 void VanitySearch::Search(std::vector<int> gpuId, std::vector<int> gridSize) {
 
 	double t0;
@@ -1082,8 +1096,6 @@ void VanitySearch::Search(std::vector<int> gpuId, std::vector<int> gridSize) {
 	uint64_t gpuCount = 0;	
 
 	double timeout60sec = 0;
-	Int lastSaveKey; 
-	lastSaveKey.SetInt32(0);
 
 	// Key rate smoothing filter
 #define FILTER_SIZE 20
@@ -1135,17 +1147,16 @@ void VanitySearch::Search(std::vector<int> gpuId, std::vector<int> gridSize) {
 		}
 
 		timeout60sec += (t1 - t0);
-		if (timeout60sec > 2.0) {	
+		if (timeout60sec > 5.0) {
 
-			// Save LowerPrivKey as saveProgress
-			/*saveProgress(params, lastSaveKey, bc);
-
-			// Reached end of keyspace
-			if (lastSaveKey.IsGreaterOrEqual(&bc->ksFinish)) {
-				endOfSearch = true;
-				fprintf(stdout, "[EXIT] Range search completed \n");	
-				fflush(stdout);
-			}*/
+			// Persist scan progress for crash-safe resume.
+			// Single-GPU only: with >1 GPU, getGPUCount() sums all devices while
+			// savedNumThreads is one device's thread count, so the offset would be wrong.
+			if (progressCallback && savedNumThreads > 0 && numGPUs == 1) {
+				Int off = RangeMath::offsetFromCount(getGPUCount(), savedNumThreads);
+				off.Add(&appliedResumeOffset);  // absolute offset (resume base + this run's advance)
+				progressCallback(off, savedNumThreads);
+			}
 
 			timeout60sec = 0.0;
 		}

--- a/Vanity.h
+++ b/Vanity.h
@@ -97,6 +97,16 @@ public:
 		keyCallback = cb;
 	}
 
+	// Progress persistence (pool save/resume)
+	typedef std::function<void(Int&, int)> ProgressCallback;
+	void setProgressCallback(ProgressCallback cb) { progressCallback = cb; }
+	// Resume an interrupted range: shift each GPU thread by `offset` if the thread
+	// count matches `expectedThreads`; otherwise FindKeyGPU falls back to a full re-scan.
+	void setResume(Int& offset, int expectedThreads) {
+		resumeOffset.Set(&offset);
+		resumeExpectedThreads = expectedThreads;
+	}
+
 private:
 
 	std::string GetHex(std::vector<unsigned char>& buffer);
@@ -133,6 +143,11 @@ private:
 	uint64_t      counters[256];
 	double startTime;
 	KeyFoundCallback keyCallback;
+	ProgressCallback progressCallback;
+	Int resumeOffset;
+	Int appliedResumeOffset;
+	int resumeExpectedThreads;
+	int savedNumThreads;
 	int searchType;
 	int searchMode;
 	bool stopWhenFound;
@@ -149,7 +164,6 @@ private:
 	std::vector<std::string>& inputAddresses;
 
 	BITCRACK_PARAM* bc;
-	void saveProgress(TH_PARAM* p, Int& lastSaveKey, BITCRACK_PARAM* bc);
 
 	Int firstGPUThreadLastPrivateKey;
 

--- a/VanitySearch.vcxproj
+++ b/VanitySearch.vcxproj
@@ -33,6 +33,8 @@
     <ClInclude Include="SECP256k1.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="Vanity.h" />
+    <ClInclude Include="RangeMath.h" />
+    <ClInclude Include="Pool\Checkpoint.h" />
     <ClInclude Include="Wildcard.h" />
   </ItemGroup>
   <ItemGroup>
@@ -57,6 +59,8 @@
     <ClCompile Include="SECP256K1.cpp" />
     <ClCompile Include="Timer.cpp" />
     <ClCompile Include="Vanity.cpp" />
+    <ClCompile Include="RangeMath.cpp" />
+    <ClCompile Include="Pool\Checkpoint.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CudaCompile Include="GPU\GPUEngine.cu">

--- a/VanitySearch.vcxproj.filters
+++ b/VanitySearch.vcxproj.filters
@@ -37,6 +37,7 @@
     <ClInclude Include="SECP256k1.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="Vanity.h" />
+    <ClInclude Include="RangeMath.h" />
     <ClInclude Include="Base58.h" />
     <ClInclude Include="GPU\GPUHash.h">
       <Filter>GPU</Filter>
@@ -59,6 +60,9 @@
       <Filter>Pool</Filter>
     </ClInclude>
     <ClInclude Include="Pool\PoolConfig.h">
+      <Filter>Pool</Filter>
+    </ClInclude>
+    <ClInclude Include="Pool\Checkpoint.h">
       <Filter>Pool</Filter>
     </ClInclude>
   </ItemGroup>
@@ -89,6 +93,7 @@
     <ClCompile Include="SECP256K1.cpp" />
     <ClCompile Include="Timer.cpp" />
     <ClCompile Include="Vanity.cpp" />
+    <ClCompile Include="RangeMath.cpp" />
     <ClCompile Include="Base58.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Bech32.cpp" />
@@ -100,6 +105,9 @@
       <Filter>Pool</Filter>
     </ClCompile>
     <ClCompile Include="Pool\PoolConfig.cpp">
+      <Filter>Pool</Filter>
+    </ClCompile>
+    <ClCompile Include="Pool\Checkpoint.cpp">
       <Filter>Pool</Filter>
     </ClCompile>
     <ClCompile Include="local.props" />

--- a/btcpuzzle.sh
+++ b/btcpuzzle.sh
@@ -32,6 +32,7 @@ do
   [ -n "$TELEGRAM_CHATID" ] && CMD+=("-telegramchatid" "$TELEGRAM_CHATID")
   [ -n "$CUSTOM_RANGE" ] && CMD+=("-customrange" "$CUSTOM_RANGE")
   [ -n "$SAVE_KEY" ] && [ "$SAVE_KEY" != "false" ] && CMD+=("-savekey" "$SAVE_KEY")
+  [ -n "$SAVE_PROGRESS" ] && CMD+=("-saveprogress" "$SAVE_PROGRESS")
 
   CURRENT_WORKER="${BASE_WORKER}_${i}"
   CMD+=("-worker" "$CURRENT_WORKER")

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 #include "hash/sha256.h"
 #include "Pool/PoolConfig.h"
 #include "Pool/PoolClient.h"
+#include "Pool/Checkpoint.h"
 #include <iostream>
 #include <filesystem>
 #include <thread>
@@ -607,6 +608,15 @@ int main(int argc, char* argv[]) {
 			g_poolConfig.saveKeyToBtcPuzzle = argv[a];
 			a++;
 		}
+		else if (strcmp(argv[a], "-saveprogress") == 0) {
+			if (a + 1 >= argc || (argv[a + 1][0] == '-' && argv[a + 1][1] != '\0')) {
+				fprintf(stderr, "-saveprogress requires a value\n");
+				exit(-1);
+			}
+			a++;
+			g_poolConfig.saveProgress = (strcmp(argv[a], "true") == 0 || strcmp(argv[a], "1") == 0);
+			a++;
+		}
 		else if (strcmp(argv[a], "-pubkey") == 0) {
 			if (a + 1 >= argc) {
 				fprintf(stderr, "-pubkey requires a value\n");
@@ -690,6 +700,164 @@ int main(int argc, char* argv[]) {
 		std::string gpuName = match[1].str();
 		g_poolConfig.gpuName = gpuName;
 	}
+
+	// Checkpoint path (one per GPU instance) + ensure progress dir exists.
+	std::string cpPath = "progress/checkpoint_gpu" + std::to_string(g_poolConfig.gpuIndex) + ".txt";
+	{
+		struct stat stp = { 0 };
+		if (stat("progress", &stp) == -1) {
+#ifdef _WIN32
+			_mkdir("progress");
+#else
+			mkdir("progress", 0755);
+#endif
+		}
+	}
+
+	// ============ RESUME: finish an interrupted range, then submit ============
+	if (g_poolMode && g_poolConfig.saveProgress) {
+		Checkpoint cp;
+		if (CheckpointIO::load(cpPath, cp)) {
+			bool stale = (cp.puzzle != g_poolConfig.targetPuzzle) || cp.hex.empty()
+				|| cp.targetAddress.empty() || cp.rangeStart.empty() || cp.rangeEnd.empty();
+			if (stale) {
+				logMessage(WARNING, "[RESUME] Stale/foreign checkpoint, discarding.");
+				CheckpointIO::clear(cpPath);
+			}
+			else {
+				logMessage(WARNING, "[RESUME] Unfinished range found; finishing before requesting a new one.");
+
+				RangeData rdata;
+				rdata.hex = cp.hex;
+				rdata.rangeStart = cp.rangeStart;
+				rdata.rangeEnd = cp.rangeEnd;
+				rdata.targetAddress = cp.targetAddress;
+				rdata.proofOfWorkAddresses = cp.proofAddresses;
+				rdata.success = true;
+
+				PoolClient rclient(g_poolConfig);
+				if (!rclient.init()) {
+					logMessage(DANGER, "[RESUME] Pool client init failed; skipping resume.");
+					CheckpointIO::clear(cpPath);
+				}
+				else {
+					// Replay proof keys found before the crash.
+					for (const auto& pr : cp.foundProof) {
+						rclient.onKeyFound(pr.first, pr.second);
+					}
+
+					// Rebuild keyspace.
+					getKeySpace(cp.hex + cp.rangeStart + ":+" + cp.rangeEnd, bc, maxKey);
+					bc->ksNext.Set(&bc->ksStart);
+					checkKeySpace(bc, maxKey);
+
+					// Recreate address file and parse.
+					struct stat st = { 0 };
+					if (stat("ranges", &st) == -1) {
+#ifdef _WIN32
+						_mkdir("ranges");
+#else
+						mkdir("ranges", 0755);
+#endif
+					}
+					std::string maskedHex = cp.hex;
+					if (maskedHex.length() >= 2 && g_poolConfig.untrustedComputer) {
+						maskedHex[1] = '_';
+						maskedHex[maskedHex.length() - 1] = '_';
+					}
+					std::string rfile = "ranges/btcpuzzle_" + maskedHex + ".txt";
+					{
+						std::ofstream out(rfile);
+						for (const auto& a : cp.proofAddresses) out << a << "\n";
+						out << cp.targetAddress << "\n";
+					}
+					address.clear();
+					parseFile(rfile, address);
+					if (g_poolConfig.untrustedComputer) std::remove(rfile.c_str());
+
+					VanitySearch* rv = new VanitySearch(secp, address, searchMode, stop, outputFile, maxFound, bc);
+					rclient.startPing(rdata.hex);
+					rv->setKeyFoundCallback([&](std::string addr, std::string key) {
+						while (key.length() < 64) key = "0" + key;
+						rclient.onKeyFound(addr, key);
+						if (addr == rdata.targetAddress) {
+							printf("\n*** TARGET KEY FOUND (during resume)! ***\n");
+							rclient.notifyTargetFound(addr, key);
+							std::string fn = "WINNER_" + addr.substr(0, 8) + ".txt";
+							std::ofstream of(fn);
+							if (of.is_open()) {
+								of << "Target Address: " << addr << "\n\n";
+								if (g_poolConfig.untrustedComputer)
+									of << "Private Key: " << rclient.encryptData(key) << "\n";
+								else
+									of << "Private Key: " << key << "\n";
+							}
+						}
+					});
+
+					Int rOff; rOff.SetInt32(0);
+					if (!cp.offsetHex.empty()) rOff.SetBase16((char*)cp.offsetHex.c_str());
+					rv->setResume(rOff, cp.numThreads);
+
+					// Keep checkpointing DURING the resume scan too, so a crash mid-resume
+					// doesn't restart the whole remainder. off is already absolute.
+					if (g_poolConfig.saveProgress) {
+						rv->setProgressCallback([&](Int& off, int n) {
+							Checkpoint cp2;
+							cp2.puzzle = g_poolConfig.targetPuzzle;
+							cp2.hex = rdata.hex;
+							cp2.rangeStart = rdata.rangeStart;
+							cp2.rangeEnd = rdata.rangeEnd;
+							cp2.targetAddress = rdata.targetAddress;
+							cp2.proofAddresses = rdata.proofOfWorkAddresses;
+							cp2.numThreads = n;
+							cp2.offsetHex = off.GetBase16();
+							cp2.foundProof = rclient.getFoundProofPairs(rdata);
+							CheckpointIO::save(cpPath, cp2);
+						});
+					}
+
+					rv->Search(gpuId, gridSize);
+					rclient.stopPing();
+
+					if (rclient.hasAllProofKeys(rdata)) {
+						auto proofKeys = rclient.getProofKeys(rdata);
+						bool done = false;
+						for (int attempt = 1; attempt <= 3 && !done; attempt++) {
+							if (rclient.submitRange(rdata.hex, proofKeys)) {
+								rclient.notifyRangeScanned(rdata.hex);
+								logMessage(SUCCESS, "[RESUME] Finished range submitted.");
+								done = true;
+							}
+							else {
+								logMessage(DANGER, "[RESUME] Submit failed, retrying...");
+								std::this_thread::sleep_for(std::chrono::seconds(5));
+							}
+						}
+						if (!done) {
+							std::string errFile = "FLAG_ERROR_" + rdata.hex + ".txt";
+							std::ofstream eo(errFile);
+							if (eo.is_open()) {
+								eo << "Range: " << rdata.hex << "\n";
+								for (auto& k : proofKeys) eo << k << "\n";
+							}
+							logMessage(WARNING, "[RESUME] Pool did not accept the range; proof keys backed up.");
+						}
+					}
+					else {
+						logMessage(DANGER, "[RESUME] Not all proof keys after re-scan; discarding.");
+					}
+
+					delete rv;
+					rclient.reset();
+					CheckpointIO::clear(cpPath);
+				}
+			}
+		}
+	}
+
+	// Reset the address list after any resume scan before entering the main loop.
+	address.clear();
 
 	int loops = 0;
 	while (true)
@@ -876,6 +1044,22 @@ int main(int argc, char* argv[]) {
 
 				}
 				});
+
+			if (g_poolConfig.saveProgress) {
+				v->setProgressCallback([&](Int& off, int n) {
+					Checkpoint cp;
+					cp.puzzle = g_poolConfig.targetPuzzle;
+					cp.hex = rangeData.hex;
+					cp.rangeStart = rangeData.rangeStart;
+					cp.rangeEnd = rangeData.rangeEnd;
+					cp.targetAddress = rangeData.targetAddress;
+					cp.proofAddresses = rangeData.proofOfWorkAddresses;
+					cp.numThreads = n;
+					cp.offsetHex = off.GetBase16();
+					cp.foundProof = client.getFoundProofPairs(rangeData);
+					CheckpointIO::save(cpPath, cp);
+				});
+			}
 		}
 
 		// Start search
@@ -961,6 +1145,7 @@ int main(int argc, char* argv[]) {
 			}
 
 			// Clean up
+			if (g_poolConfig.saveProgress) CheckpointIO::clear(cpPath);
 			client.reset();
 			loops++;
 

--- a/pool.conf
+++ b/pool.conf
@@ -31,3 +31,6 @@ save_key=false
 
 # Other Settings
 custom_range=none
+
+# Save/resume scan progress (resume an interrupted range on restart)
+save_progress=true

--- a/tests/test_checkpoint.cpp
+++ b/tests/test_checkpoint.cpp
@@ -1,0 +1,82 @@
+#include "Checkpoint.h"
+#include <cstdio>
+#include <string>
+
+static int failures = 0;
+#define CHECK(cond) do { if(!(cond)) { printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); failures++; } } while(0)
+
+int main() {
+    const std::string path = "/tmp/btc_cp_test.txt";
+    CheckpointIO::clear(path);
+
+    // round-trip with lists and pairs
+    Checkpoint cp;
+    cp.puzzle = 71;
+    cp.hex = "2A";
+    cp.rangeStart = "0000000000000001";
+    cp.rangeEnd = "0000000000100000";
+    cp.targetAddress = "1PWo3JeB9jrGwfHDNpdGK54CRas7fsVzXU";
+    cp.proofAddresses = {"1AddrOne", "1AddrTwo", "1AddrThree"};
+    cp.numThreads = 131072;
+    cp.offsetHex = "ABCDEF";
+    cp.foundProof = { {"1AddrOne", "00FF11"}, {"1AddrTwo", "DEADBEEF"} };
+    CHECK(CheckpointIO::save(path, cp));
+
+    Checkpoint got;
+    CHECK(CheckpointIO::load(path, got));
+    CHECK(got.puzzle == 71);
+    CHECK(got.hex == "2A");
+    CHECK(got.rangeStart == cp.rangeStart);
+    CHECK(got.rangeEnd == cp.rangeEnd);
+    CHECK(got.targetAddress == cp.targetAddress);
+    CHECK(got.numThreads == 131072);
+    CHECK(got.offsetHex == "ABCDEF");
+    CHECK(got.proofAddresses.size() == 3);
+    CHECK(got.proofAddresses[2] == "1AddrThree");
+    CHECK(got.foundProof.size() == 2);
+    CHECK(got.foundProof[1].first == "1AddrTwo");
+    CHECK(got.foundProof[1].second == "DEADBEEF");
+
+    // no temp file left behind
+    FILE* tmp = fopen((path + ".tmp").c_str(), "r");
+    CHECK(tmp == NULL);
+    if (tmp) fclose(tmp);
+
+    // missing file -> false
+    CheckpointIO::clear(path);
+    Checkpoint none;
+    CHECK(CheckpointIO::load(path, none) == false);
+
+    // corrupted file (no header) -> false
+    FILE* f = fopen(path.c_str(), "w");
+    fputs("garbage line\nfoo=bar\n", f);
+    fclose(f);
+    Checkpoint bad;
+    CHECK(CheckpointIO::load(path, bad) == false);
+    CheckpointIO::clear(path);
+
+    // malformed integer field -> load returns false
+    {
+        FILE* g = fopen(path.c_str(), "w");
+        fputs("btcpuzzle-checkpoint v1\npuzzle=71\nnumThreads=abc\n", g);
+        fclose(g);
+        Checkpoint badi;
+        CHECK(CheckpointIO::load(path, badi) == false);
+        CheckpointIO::clear(path);
+    }
+
+    // malformed found line (no space) is skipped, but load still succeeds
+    {
+        FILE* g = fopen(path.c_str(), "w");
+        fputs("btcpuzzle-checkpoint v1\npuzzle=71\nnumThreads=4\nfound=NoSpaceHere\n", g);
+        fclose(g);
+        Checkpoint okp;
+        CHECK(CheckpointIO::load(path, okp) == true);
+        CHECK(okp.foundProof.empty());
+        CheckpointIO::clear(path);
+    }
+
+    if (failures == 0) { printf("ALL CHECKPOINT TESTS PASSED\n"); return 0; }
+    printf("%d CHECK(S) FAILED\n", failures);
+    return 1;
+}

--- a/tests/test_rangemath.cpp
+++ b/tests/test_rangemath.cpp
@@ -1,0 +1,50 @@
+#include "RangeMath.h"
+#include <cstdio>
+
+static int failures = 0;
+#define CHECK(cond) do { if(!(cond)) { printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); failures++; } } while(0)
+
+static bool eq(Int a, Int b) { return a.IsEqual(&b); }  // by value -> safe to call non-const
+
+int main() {
+    // start=0x100, end=0x140, N=4 -> diff=0x10
+    Int start; start.SetBase16((char*)"100");
+    Int end;   end.SetBase16((char*)"140");
+    Int diff = RangeMath::perThreadDiff(start, end, 4);
+    Int expDiff; expDiff.SetBase16((char*)"10");
+    CHECK(eq(diff, expDiff));
+
+    // thread starts: 0x100, 0x110, 0x120, 0x130
+    const char* exp[4] = { "100", "110", "120", "130" };
+    for (int i = 0; i < 4; i++) {
+        Int s = RangeMath::threadStart(start, diff, i);
+        Int e; e.SetBase16((char*)exp[i]);
+        CHECK(eq(s, e));
+    }
+
+    // coverage with offset=0x6: [s_i, s_i+6) U [s_i+6, s_{i+1}) tiles range, no gaps
+    Int offset; offset.SetBase16((char*)"6");
+    for (int i = 0; i < 4; i++) {
+        Int s     = RangeMath::threadStart(start, diff, i);
+        Int sNext = RangeMath::threadStart(start, diff, i + 1);
+        Int mid(&s); mid.Add(&offset);          // s_i + offset
+        CHECK(mid.IsGreater(&s));                // pre-crash part non-empty
+        CHECK(sNext.IsGreater(&mid));            // post part non-empty (offset < diff)
+        Int chk(&s); chk.Add(&diff);            // s_i + diff == s_{i+1} (contiguous)
+        CHECK(eq(chk, sNext));
+    }
+
+    // offsetFromCount: 0x40 keys over N=4 -> 0x10 per thread; floors 0x41 -> 0x10
+    Int e10; e10.SetBase16((char*)"10");
+    CHECK(eq(RangeMath::offsetFromCount(0x40, 4), e10));
+    CHECK(eq(RangeMath::offsetFromCount(0x41, 4), e10));
+
+    // guard: non-positive thread count returns zero (no division by zero)
+    Int zero; zero.SetInt32(0);
+    CHECK(eq(RangeMath::perThreadDiff(start, end, 0), zero));
+    CHECK(eq(RangeMath::offsetFromCount(0x40, 0), zero));
+
+    if (failures == 0) { printf("ALL RANGEMATH TESTS PASSED\n"); return 0; }
+    printf("%d CHECK(S) FAILED\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Adds opt-in save/resume of GPU scan progress so an interrupted range isn't lost on restart.

While scanning a pool range, the client periodically writes a crash-safe checkpoint (range identity + per-thread scan offset + found proof keys) to `progress/checkpoint_gpu<idx>.txt`. On startup, **before** requesting a new range, it finishes the interrupted range from the saved offset, submits its proof keys, then continues normally.

**Why finish-and-submit:** the pool assigns a new range on restart and the same range can't be re-requested, so resuming the exact pool range isn't possible. Instead the client completes the interrupted range — exact resume when the GPU thread count matches the checkpoint, full re-scan otherwise — and submits it.

## Changes
- `Pool/Checkpoint.{h,cpp}` — atomic checkpoint (temp + rename) serialization
- `RangeMath.{h,cpp}` — GPU partition arithmetic, kept in sync with `getGPUStartingKeysMT`
- `VanitySearch` — resume offset applied per GPU thread; periodic progress callback (single-GPU)
- `PoolClient` — `std::mutex` around `foundKeys` (now read concurrently by the monitor thread) + `getFoundProofPairs`
- `main.cpp` — resume branch + checkpoint write/clear lifecycle
- `save_progress` flag — `pool.conf` / `-saveprogress` / Docker `SAVE_PROGRESS` (default on)
- Build wiring: `Makefile`, VS project, `.gitignore` (`/progress`), `README`, `Dockerfile`, `btcpuzzle.sh`

**Privacy:** the checkpoint never stores the target private key (only proof keys, which already go to the pool), so untrusted-computer mode's guarantee is preserved.

## Testing
- Unit tests for `Checkpoint` (round-trip, atomicity, corrupted file) and `RangeMath` (partition tiling, floor offset) under `tests/` — each builds & runs with a single `g++` command (in-file).
- Full CUDA build verified on Linux (Docker) and Windows (MSBuild).
- End-to-end on puzzle 71 (RTX 5070): checkpoint written with advancing offset; after kill+restart the client logs `[RESUME] resumed from per-thread offset 0x...` and finishes the range.

## Notes
- `save_progress` defaults to `true`; set `save_progress=false` to disable.
- Removes a dead `saveProgress()` stub that was never wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)